### PR TITLE
Refactor main.py into modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 tokens.json
+.venv/

--- a/client.py
+++ b/client.py
@@ -1,0 +1,67 @@
+import logging
+import time
+from datetime import datetime, timezone, timedelta
+import requests
+import schwabdev
+
+
+def create_schwab_client(key: str, secret: str):
+    """Instantiate and return a Schwabdev client."""
+    logging.debug("Initializing Schwabdev client")
+    return schwabdev.Client(key, secret)
+
+
+def _get_end_time(delta: int = 1) -> str:
+    to_date = datetime.now(timezone.utc)
+    from_date = to_date - timedelta(hours=delta)
+    return from_date.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+
+
+def _get_start_time(delta: int = 1) -> str:
+    to_date = datetime.now(timezone.utc)
+    return to_date.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+
+
+def retry_request(
+    request_func,
+    retries: int = 3,
+    delay: int = 5,
+    backoff: int = 2,
+    retry_on=(requests.exceptions.RequestException,),
+    raise_on_fail: bool = False,
+):
+    """Retry a request with exponential backoff."""
+    last_exc = None
+    for attempt in range(1, retries + 1):
+        try:
+            return request_func()
+        except retry_on as e:
+            last_exc = e
+            logging.warning(
+                f"[Attempt {attempt}] Request failed: {e}. Retrying in {delay}s..."
+            )
+            time.sleep(delay)
+            delay *= backoff
+    logging.error("All retry attempts failed.")
+    if raise_on_fail and last_exc is not None:
+        raise last_exc
+    return None
+
+
+class SchwabClient:
+    """Wrapper around schwabdev.Client with retry logic."""
+
+    def __init__(self, key: str, secret: str):
+        self.client = create_schwab_client(key, secret)
+
+    def get_account_positions(self, status: str | None = None, hours: int = 1):
+        def fetch_orders():
+            to_date_str = _get_start_time(hours)
+            from_date_str = _get_end_time(hours)
+            return self.client.account_orders_all(from_date_str, to_date_str, None, status)
+
+        response = retry_request(fetch_orders, raise_on_fail=True)
+        if response is not None and response.status_code == 200:
+            return response.json()
+        logging.error(f"Failed to get account positions after retries. Response: {response}")
+        return None

--- a/flatten.py
+++ b/flatten.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+
+def extract_nested_value(obj, path, context: dict | None = None):
+    """Safely navigate a nested structure using a list of keys/indexes."""
+    context = context or {}
+    for key in path:
+        if isinstance(key, str) and key.startswith("{") and key.endswith("}"):
+            key = context.get(key.strip("{}"))
+        try:
+            obj = obj[key]
+        except (KeyError, IndexError, TypeError):
+            return None
+    return obj
+
+
+def extract_and_append(trade, mapping, leg_index):
+    """Build a flat dictionary using mapping rules and leg index."""
+    flat = {}
+    for key, path in mapping.items():
+        flat[key] = extract_nested_value(trade, path, context={"leg": leg_index})
+    return flat
+
+
+def flatten_trade_with_mapping(trade, mapping):
+    legs = trade.get("orderLegCollection", [])
+    results = []
+    for i in range(len(legs)):
+        flat = extract_and_append(trade, mapping, i)
+        flat["multi_leg"] = len(legs) > 1
+        results.append(flat)
+    return results
+
+
+def flatten_data(trade):
+    mapping = {
+        "symbol": ["orderLegCollection", "{leg}", "instrument", "symbol"],
+        "underlying": ["orderLegCollection", "{leg}", "instrument", "underlyingSymbol"],
+        "instruction": ["orderLegCollection", "{leg}", "instruction"],
+        "qty": ["orderLegCollection", "{leg}", "quantity"],
+        "price": ["orderActivityCollection", 0, "executionLegs", "{leg}", "price"],
+        "order_id": ["orderId"],
+        "time": ["orderActivityCollection", 0, "executionLegs", "{leg}", "time"],
+    }
+    return flatten_trade_with_mapping(trade, mapping)
+
+
+def flatten_dataset(json_data):
+    flat_trades_list = []
+    for trade in json_data:
+        flat_legs = flatten_data(trade)
+        flat_trades_list.extend(flat_legs)
+    return flat_trades_list

--- a/main.py
+++ b/main.py
@@ -1,167 +1,18 @@
-# This is a sample Python script.
 import logging
-import os
-from dotenv import load_dotenv
-import schwabdev
-from datetime import datetime, timezone, timedelta
-import time
-import requests
-import json
-# Press Ctrl+F5 to execute it or replace it with your code.
-# Press Double Shift to search everywhere for classes, files, tool windows, actions, and settings.
-logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+from client import SchwabClient
+from secrets import get_secret
+from flatten import flatten_dataset
 
 
-def create_schwab_client(key, secret):
-    logging.debug("Initializing Schwabdev client")
-    return schwabdev.Client(key, secret)
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s - %(levelname)s - %(message)s')
 
 
-def get_end_time(delta=1):
-    """
-    Returns the current time minus the given delta hours as a string in ISO 8601 format with milliseconds and timezone.
-
-    Args:
-        delta: int, optional
-            The number of hours to subtract from the current time. Defaults to 1.
-
-    Returns:
-        str
-            The current time minus delta hours as an ISO 8601 string.
-    """
-
-    to_date = datetime.now(timezone.utc)
-    from_date = to_date - timedelta(hours=delta)
-
-    # Format dates as ISO 8601 strings with milliseconds and timezone
-    return from_date.strftime('%Y-%m-%dT%H:%M:%S.000Z')
-
-def get_start_time(delta=1):
-    """
-    Returns the current time as a string in ISO 8601 format with milliseconds and timezone,
-    adjusted by the given delta hours.
-
-    Args:
-        delta: int, optional
-            The number of hours to subtract from the current time. Defaults to 1.
-
-    Returns:
-        str
-            The current time minus delta hours as an ISO 8601 string.
-    """
-    to_date = datetime.now(timezone.utc)
-    # Format dates as ISO 8601 strings with milliseconds and timezone
-    return to_date.strftime('%Y-%m-%dT%H:%M:%S.000Z')
-
-def retry_request(request_func, retries=3, delay=5, backoff=2, retry_on=(requests.exceptions.RequestException,), raise_on_fail=False):
-    for attempt in range(1, retries + 1):
-        try:
-            return request_func()
-        except retry_on as e:
-            logging.warning(f"[Attempt {attempt}] Request failed: {e}. Retrying in {delay}s...")
-            time.sleep(delay)
-            delay *= backoff
-
-    logging.error("All retry attempts failed.")
-    if raise_on_fail:
-        raise e  # re-raise the last exception
-    return None
-
-class SchwabClient:
-    def __init__(self, account, secret):
-        self.client = create_schwab_client(app_key, app_secret)
-
-    def get_account_positions(self, status=None, hours=1):
-        def fetch_orders():
-            to_date_str = get_start_time(hours)
-            from_date_str = get_end_time(hours)
-            return self.client.account_orders_all(from_date_str, to_date_str, None, status)
-
-        response = retry_request(fetch_orders, raise_on_fail=True)
-        if response is not None and response.status_code == 200:
-            return response.json()
-        else:
-            logging.error(f"Failed to get account positions after retries. Response: {response}")
-            return None
-
-def get_secret(key, path="./"):
-    try:
-        load_dotenv(path)
-        value = os.getenv(key)
-        if value is None:
-            #throw error if key not found
-            raise Exception ("Key not found / is None")
-        return value
-    except Exception as e:
-        logging.error(f"Error getting secret from {path}: {e}")
-        return None
-
-def get_last_week_trades(client, status= "FILLED", delta = 168):
-    json_data = client.get_account_positions(status, delta)
-    return json_data
-
-def extract_nested_value(obj, path, context=None):
-    """
-    Safely navigates a nested structure using a list of keys/indexes.
-    Supports placeholder substitution like "{leg}".
-    """
-    context = context or {}
-    for key in path:
-        # Replace placeholders like "{leg}" using context
-        if isinstance(key, str) and key.startswith("{") and key.endswith("}"):
-            key = context.get(key.strip("{}"))
-
-        try:
-            obj = obj[key]
-        except (KeyError, IndexError, TypeError):
-            return None
-    return obj
+def get_last_week_trades(client: SchwabClient, status: str = "FILLED", delta: int = 168):
+    return client.get_account_positions(status, delta)
 
 
-def extract_and_append(trade, mapping, leg_index):
-    """
-    Builds a flat dictionary by extracting values from trade using mapping rules,
-    where "{leg}" placeholders are substituted with the given leg index.
-    """
-    flat = {}
-    for key, path in mapping.items():
-        flat[key] = extract_nested_value(trade, path, context={"leg": leg_index})
-    return flat
-
-def flatten_trade_with_mapping(trade, mapping):
-    legs = trade.get("orderLegCollection", [])
-    results = []
-    for i in range(len(legs)):
-        flat = extract_and_append(trade, mapping, i)
-        flat["multi_leg"] = len(legs) > 1
-        results.append(flat)
-    return results
-
-def flatten_data(trade):
-    flat_trade = {}
-
-    mapping = {
-        "symbol": ["orderLegCollection", "{leg}", "instrument", "symbol"],
-        "underlying": ["orderLegCollection", "{leg}", "instrument", "underlyingSymbol"],
-        "instruction": ["orderLegCollection", "{leg}", "instruction"],
-        "qty": ["orderLegCollection", "{leg}", "quantity"],
-        "price": ["orderActivityCollection", 0, "executionLegs", "{leg}", "price"],
-        "order_id": ["orderId"],
-        "time": ["orderActivityCollection", 0, "executionLegs", "{leg}", "time"],
-    }
-
-    flat_trade = flatten_trade_with_mapping(trade, mapping)
-    return flat_trade
-
-
-def flatten_dataset(json_data):
-    flat_trades_list = []
-    for trade in json_data:
-        flat_legs = flatten_data(trade)
-        flat_trades_list.extend(flat_legs)  # Use extend, not append
-    return flat_trades_list
-
-if __name__ == '__main__':
+def main():
     file_path = ".env"
     app_key = get_secret("SCHWAB_APP_KEY", file_path)
     app_secret = get_secret("SCHWAB_APP_SECRET", file_path)
@@ -175,3 +26,6 @@ if __name__ == '__main__':
 
     logging.info("Trade data exported to schwab_trades.json")
 
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "schwabdev>=2.5.0",
 ]
+
+[project.scripts]
+account-tracker = "main:main"

--- a/secrets.py
+++ b/secrets.py
@@ -1,0 +1,16 @@
+import logging
+import os
+from dotenv import load_dotenv
+
+
+def get_secret(key: str, path: str = "./"):
+    """Load a single secret from the given dotenv path."""
+    try:
+        load_dotenv(path)
+        value = os.getenv(key)
+        if value is None:
+            raise Exception("Key not found / is None")
+        return value
+    except Exception as e:
+        logging.error(f"Error getting secret from {path}: {e}")
+        return None


### PR DESCRIPTION
## Summary
- extract Schwab client helpers into `client.py`
- move secret helper into `secrets.py`
- add trade data flatten helpers in `flatten.py`
- reduce `main.py` to orchestrate loading secrets, fetching data and flattening
- expose CLI entry point via `pyproject.toml`
- ignore `.venv` in git

## Testing
- `python -m py_compile main.py client.py flatten.py secrets.py`

------
https://chatgpt.com/codex/tasks/task_e_687903835fe88323bd2cf1c3c0220048