### PR TITLE
Add pytest tests and configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,8 @@ dependencies = [
 
 [project.scripts]
 account-tracker = "main:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0"
+]

--- a/tests/fixtures/sample_orders.json
+++ b/tests/fixtures/sample_orders.json
@@ -1,0 +1,42 @@
+[
+  {
+    "orderId": 1,
+    "orderLegCollection": [
+      {
+        "instrument": {"symbol": "AAPL", "underlyingSymbol": "AAPL"},
+        "instruction": "BUY",
+        "quantity": 10
+      }
+    ],
+    "orderActivityCollection": [
+      {
+        "executionLegs": [
+          {"price": 100.0, "time": "2024-01-01T00:00:00.000Z"}
+        ]
+      }
+    ]
+  },
+  {
+    "orderId": 2,
+    "orderLegCollection": [
+      {
+        "instrument": {"symbol": "MSFT", "underlyingSymbol": "MSFT"},
+        "instruction": "SELL",
+        "quantity": 5
+      },
+      {
+        "instrument": {"symbol": "MSFT", "underlyingSymbol": "MSFT"},
+        "instruction": "BUY",
+        "quantity": 5
+      }
+    ],
+    "orderActivityCollection": [
+      {
+        "executionLegs": [
+          {"price": 200.0, "time": "2024-01-02T00:00:00.000Z"},
+          {"price": 201.0, "time": "2024-01-02T00:00:00.000Z"}
+        ]
+      }
+    ]
+  }
+]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock, patch
+import sys
+from pathlib import Path
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.modules.setdefault("schwabdev", Mock())
+
+from client import SchwabClient
+
+
+@patch('client.create_schwab_client')
+@patch('client.time.sleep', return_value=None)
+def test_get_account_positions_retries(mock_sleep, mock_create):
+    mock_api = Mock()
+    mock_create.return_value = mock_api
+
+    success_response = Mock()
+    success_response.status_code = 200
+    success_response.json.return_value = {'ok': True}
+
+    def side_effect(*args, **kwargs):
+        if side_effect.calls < 2:
+            side_effect.calls += 1
+            raise requests.exceptions.RequestException('fail')
+        return success_response
+    side_effect.calls = 0
+
+    mock_api.account_orders_all.side_effect = side_effect
+
+    client = SchwabClient('key', 'secret')
+    result = client.get_account_positions()
+
+    assert result == {'ok': True}
+    assert mock_api.account_orders_all.call_count == 3
+    assert mock_sleep.call_count == 2

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -1,0 +1,64 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from flatten import flatten_data, flatten_dataset
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_orders.json"
+
+with open(FIXTURE) as f:
+    SAMPLE_ORDERS = json.load(f)
+
+
+def test_flatten_data_single():
+    result = flatten_data(SAMPLE_ORDERS[0])
+    expected = [{
+        "symbol": "AAPL",
+        "underlying": "AAPL",
+        "instruction": "BUY",
+        "qty": 10,
+        "price": 100.0,
+        "order_id": 1,
+        "time": "2024-01-01T00:00:00.000Z",
+        "multi_leg": False
+    }]
+    assert result == expected
+
+
+def test_flatten_dataset_full():
+    result = flatten_dataset(SAMPLE_ORDERS)
+    expected = [
+        {
+            "symbol": "AAPL",
+            "underlying": "AAPL",
+            "instruction": "BUY",
+            "qty": 10,
+            "price": 100.0,
+            "order_id": 1,
+            "time": "2024-01-01T00:00:00.000Z",
+            "multi_leg": False
+        },
+        {
+            "symbol": "MSFT",
+            "underlying": "MSFT",
+            "instruction": "SELL",
+            "qty": 5,
+            "price": 200.0,
+            "order_id": 2,
+            "time": "2024-01-02T00:00:00.000Z",
+            "multi_leg": True
+        },
+        {
+            "symbol": "MSFT",
+            "underlying": "MSFT",
+            "instruction": "BUY",
+            "qty": 5,
+            "price": 201.0,
+            "order_id": 2,
+            "time": "2024-01-02T00:00:00.000Z",
+            "multi_leg": True
+        }
+    ]
+    assert result == expected


### PR DESCRIPTION
## Summary
- add unit tests for flatten functions
- test SchwabClient retry logic using mocks
- include pytest as dev dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687927403afc8323a64a33bca34d38c8