### PR TITLE
Add price tracker and integrate with poller

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import signal
 from client import SchwabClient
 from secrets import get_secret
 from poller import poll_schwab
+from tracker import PriceTracker
 
 
 logging.basicConfig(level=logging.DEBUG,
@@ -23,10 +24,11 @@ def main():
     app_key = get_secret("SCHWAB_APP_KEY", file_path)
     app_secret = get_secret("SCHWAB_APP_SECRET", file_path)
     client = SchwabClient(app_key, app_secret)
+    tracker = PriceTracker()
 
     interval = float(os.getenv("POLL_INTERVAL", 5))
     loop = asyncio.get_event_loop()
-    task = loop.create_task(poll_schwab(client, interval))
+    task = loop.create_task(poll_schwab(client, interval, tracker))
 
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, task.cancel)

--- a/poller.py
+++ b/poller.py
@@ -2,16 +2,40 @@ import asyncio
 import logging
 
 from client import SchwabClient
+from flatten import flatten_dataset
+from tracker import PriceTracker
 
 
-async def poll_schwab(client: SchwabClient, interval_secs: float = 5) -> None:
-    """Continuously poll ``client`` for account positions."""
+async def poll_schwab(
+    client: SchwabClient,
+    interval_secs: float = 5,
+    tracker: PriceTracker | None = None,
+) -> None:
+    """Continuously poll ``client`` for account positions.
+
+    Each fetched trade is flattened, fed into ``tracker`` and the percent
+    change from the previous price is logged.
+    """
+    tracker = tracker or PriceTracker()
+
     while True:
         try:
-            client.get_account_positions()
+            data = client.get_account_positions()
+            if data:
+                trades = flatten_dataset(data)
+                for trade in trades:
+                    symbol = trade.get("symbol")
+                    price = trade.get("price")
+                    if symbol is None or price is None:
+                        continue
+                    change = tracker.update_and_get_change(symbol, float(price))
+                    logging.info(
+                        "Contract %s change %.2f%%", symbol, change
+                    )
         except Exception as exc:  # pragma: no cover - logging only
             logging.error("Polling error: %s", exc)
         try:
             await asyncio.sleep(interval_secs)
         except asyncio.CancelledError:
             break
+

--- a/tests/manual_tests.md
+++ b/tests/manual_tests.md
@@ -13,3 +13,7 @@
 3. **API Rate Limiting**
    - Simulate repeated polling causing rate limit errors.
    - Ensure the poller logs retry attempts and continues running.
+
+4. **Price Tracking**
+   - Run the poller with sample trades and verify that price changes are logged
+     correctly for each contract.

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -7,6 +7,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from poller import poll_schwab  # noqa: E402
+from tracker import PriceTracker  # noqa: E402
 
 
 def test_poll_schwab_calls_client_once():
@@ -23,3 +24,30 @@ def test_poll_schwab_calls_client_once():
 
     asyncio.run(run_poll())
     assert client.get_account_positions.called
+
+
+def test_poll_schwab_tracks_changes(monkeypatch):
+    client = Mock()
+    client.get_account_positions.return_value = ["dummy"]
+
+    recorded = []
+
+    async def run_poll():
+        tracker = PriceTracker()
+
+        def fake_flatten(data):
+            return [{"symbol": "AAPL", "price": 100.0}]
+
+        monkeypatch.setattr("poller.flatten_dataset", fake_flatten)
+
+        task = asyncio.create_task(poll_schwab(client, interval_secs=0, tracker=tracker))
+        await asyncio.sleep(0.01)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        recorded.append(tracker.last_prices["AAPL"])
+
+    asyncio.run(run_poll())
+    assert recorded == [100.0]

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tracker import PriceTracker
+
+
+def test_update_and_get_change():
+    tracker = PriceTracker()
+    first = tracker.update_and_get_change("AAPL", 100.0)
+    second = tracker.update_and_get_change("AAPL", 110.0)
+    assert first == 0.0
+    assert round(second, 2) == 10.0

--- a/tracker.py
+++ b/tracker.py
@@ -1,0 +1,17 @@
+class PriceTracker:
+    """Track last seen prices for contract identifiers."""
+
+    def __init__(self):
+        self.last_prices: dict[str, float] = {}
+
+    def update_and_get_change(self, contract: str, price: float) -> float:
+        """Update price for ``contract`` and return percent change.
+
+        If ``contract`` has not been seen before, store ``price`` and return
+        0.0.
+        """
+        previous = self.last_prices.get(contract)
+        self.last_prices[contract] = price
+        if previous is None or previous == 0:
+            return 0.0
+        return (price - previous) / previous * 100


### PR DESCRIPTION
## Summary
- add `PriceTracker` module for tracking contract prices
- log percent change for each trade via poller
- wire tracker into `main`
- document manual test for price tracking
- add unit tests for tracker and poller

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793d41172483238f96032cf0877579