### PR TITLE
Add HTTP & Discord dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ requires-python = ">=3.12"
 dependencies = [
     "python-dotenv>=1.1.0",
     "schwabdev>=2.5.0",
+    "requests>=2.32.4",
+    "discord-webhook>=1.4.1",
 ]
 
 [project.scripts]
@@ -15,3 +17,19 @@ account-tracker = "main:main"
 dev = [
     "pytest>=8.0"
 ]
+
+[tool.setuptools]
+py-modules = [
+    "client",
+    "discord_client",
+    "flatten",
+    "main",
+    "messaging",
+    "poller",
+    "secrets",
+    "tracker",
+]
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add HTTP library `requests` and the `discord-webhook` client
- define packaging metadata for editable installs

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687943e75dd8832393eb6b2f363ac4d8