### PR TITLE
Add Dockerfile and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+tests/
+.env
+tokens.json
+__pycache__/
+.venv/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY pyproject.toml .
+RUN pip install .
+COPY . .
+ENTRYPOINT ["python", "main.py"]

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -75,10 +75,14 @@ def test_poll_schwab_custom_template(monkeypatch):
                 return 5.5
 
         monkeypatch.setattr(
-            "poller.flatten_dataset", lambda data: [{"symbol": "AAPL", "price": 1.0}]
+            "poller.flatten_dataset",
+            lambda data: [{"symbol": "AAPL", "price": 1.0}],
         )
         sent = []
-        monkeypatch.setattr("poller.send_message", lambda msg: sent.append(msg))
+        monkeypatch.setattr(
+            "poller.send_message",
+            lambda msg: sent.append(msg),
+        )
         task = asyncio.create_task(
             poll_schwab(
                 client,


### PR DESCRIPTION
## Summary
- add Dockerfile to run the project with Python 3.12-slim
- ignore development and test files in `.dockerignore`
- fix flake8 line length in `tests/test_poller.py`

## Testing
- `flake8 client.py discord_client.py flatten.py main.py messaging.py poller.py secrets.py tracker.py tests --exclude=.venv`
- `pytest -q`
- `docker build . -t account-tracker` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68795f802bd08323aff69b987f6a142c