### PR TITLE
Improve secret loading and add tests

### DIFF
--- a/secrets.py
+++ b/secrets.py
@@ -4,8 +4,14 @@ from dotenv import load_dotenv
 
 
 def get_secret(key: str, path: str = "./"):
-    """Load a single secret from the given dotenv path."""
+    """Load a single secret from the environment or an optional dotenv file."""
+    # Check existing environment variables first
+    value = os.getenv(key)
+    if value is not None:
+        return value
+
     try:
+        # Fallback to loading from the provided dotenv path
         load_dotenv(path)
         value = os.getenv(key)
         if value is None:

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -75,10 +75,14 @@ def test_poll_schwab_custom_template(monkeypatch):
                 return 5.5
 
         monkeypatch.setattr(
-            "poller.flatten_dataset", lambda data: [{"symbol": "AAPL", "price": 1.0}]
+            "poller.flatten_dataset",
+            lambda data: [{"symbol": "AAPL", "price": 1.0}],
         )
         sent = []
-        monkeypatch.setattr("poller.send_message", lambda msg: sent.append(msg))
+        monkeypatch.setattr(
+            "poller.send_message",
+            lambda msg: sent.append(msg),
+        )
         task = asyncio.create_task(
             poll_schwab(
                 client,

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from secrets import get_secret  # noqa: E402
+
+
+def test_get_secret_from_env(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("MY_KEY=from_file\n")
+    monkeypatch.setenv("MY_KEY", "from_env")
+    result = get_secret("MY_KEY", str(env_file))
+    assert result == "from_env"
+
+
+def test_get_secret_from_file(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("MY_KEY=from_file\n")
+    monkeypatch.delenv("MY_KEY", raising=False)
+    result = get_secret("MY_KEY", str(env_file))
+    assert result == "from_file"
+
+
+def test_get_secret_missing(monkeypatch, tmp_path, caplog):
+    env_file = tmp_path / ".env"
+    env_file.write_text("")
+    monkeypatch.delenv("MY_KEY", raising=False)
+    with caplog.at_level("ERROR"):
+        result = get_secret("MY_KEY", str(env_file))
+    assert result is None
+    assert "Error getting secret" in caplog.text


### PR DESCRIPTION
## Summary
- prioritize environment variables in `get_secret`
- fall back to `.env` file if needed
- add unit tests for `get_secret`
- fix flake8 warnings in `tests/test_poller.py`

## Testing
- `flake8 --exclude=.venv .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795f95c81c83239029906cbe3d95e0