### PR TITLE
Lower required Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Provide the following variables either in your shell environment or in a `.env` 
 
 ## Installation
 
-1. Ensure Python 3.12 or newer is available.
+1. Ensure Python 3.11 or newer is available.
 2. (Optional) Create and activate a virtual environment.
 3. Install the dependencies defined in `pyproject.toml`:
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "account-tracker"
 version = "0.1.0"
 description = "Add your description here"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     "python-dotenv>=1.1.0",
     "schwabdev>=2.5.0",


### PR DESCRIPTION
## Summary
- update Python requirement in `pyproject.toml` to `>=3.11`
- revise README instructions for Python 3.11+

## Testing
- `flake8 . --exclude=.venv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5f9a448c83238cdac9a576938ca4