### PR TITLE
Add position tracking docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,18 @@ percentages using a FIFO cost basis. These values are available as
 `open_qty` and `pnl` placeholders in the message template. They are also logged
 each time a trade is processed.
 
+### How ``open_qty`` and ``pnl`` are calculated
+
+1. **Tracking open quantity** – Every buy order adds a lot of ``qty`` at the
+   execution price to an internal queue for that symbol. Sell orders remove
+   quantity from this queue starting with the earliest lot, leaving any remainder
+   in place. This allows partial closes to be handled correctly.
+2. **Realized profit/loss** – When quantity from a lot is closed, the
+   difference between the sell price and that lot's purchase price is recorded.
+   The cumulative realized profit is divided by the total cost basis of all
+   closed lots to produce the ``pnl`` percentage.
+3. **Current open quantity** – ``open_qty`` is simply the sum of the remaining
+   quantities in the queue for the symbol.
+
 To use a custom template, pass it to `poll_schwab()` or modify the call in
 `main.py`.

--- a/tests/manual_tests.md
+++ b/tests/manual_tests.md
@@ -24,6 +24,14 @@
    - Execute a sequence of buy and sell trades.
    - Verify that open quantities and realized PnL are updated according to FIFO logic.
    - Observe the log output for open contract count and win/loss percentage after each trade.
+7. **Partial Close Handling**
+   - Buy 10 contracts of a symbol and then buy another 10 at a different price.
+   - Sell 15 contracts and confirm the open quantity is reduced to 5.
+   - Check that the first lot is closed entirely and that PnL is calculated using its purchase price plus part of the second lot.
+8. **FIFO P/L Calculation**
+   - Sell the remaining 5 contracts at a third price.
+   - The open quantity should return to zero.
+   - Verify the win/loss percentage equals total realized profit divided by the cost basis of the closed lots.
 
 ## Docker Usage
 


### PR DESCRIPTION
## Summary
- document FIFO open qty and PnL calculation
- expand manual tests for partial closes and FIFO P/L

## Testing
- `pytest -q`
- `flake8 $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687a83919ca08323b35b8970631d8fc8