### PR TITLE
Add option contract tracking

### DIFF
--- a/flatten.py
+++ b/flatten.py
@@ -59,6 +59,18 @@ def flatten_data(trade):
             "{leg}",
             "price",
         ],
+        "expiration": [
+            "orderLegCollection",
+            "{leg}",
+            "instrument",
+            "maturityDate",
+        ],
+        "strike": [
+            "orderLegCollection",
+            "{leg}",
+            "instrument",
+            "strikePrice",
+        ],
         "order_id": ["orderId"],
         "time": [
             "orderActivityCollection",

--- a/poller.py
+++ b/poller.py
@@ -35,6 +35,8 @@ async def poll_schwab(
                     price = trade.get("price")
                     qty = trade.get("qty")
                     side = trade.get("instruction")
+                    expiration = trade.get("expiration")
+                    strike = trade.get("strike")
                     if symbol is None or price is None:
                         continue
                     change = tracker.update_and_get_change(
@@ -43,12 +45,21 @@ async def poll_schwab(
                     if qty is not None and side is not None:
                         try:
                             position_tracker.add_trade(
-                                symbol, float(qty), float(price), side
+                                symbol,
+                                float(qty),
+                                float(price),
+                                side,
+                                expiration,
+                                strike,
                             )
                         except ValueError as exc:  # pragma: no cover
                             logging.error("Position tracking error: %s", exc)
-                    open_qty = position_tracker.get_open_quantity(symbol)
-                    pnl = position_tracker.calculate_pnl(symbol)
+                    open_qty = position_tracker.get_open_quantity(
+                        symbol, expiration, strike
+                    )
+                    pnl = position_tracker.calculate_pnl(
+                        symbol, expiration, strike
+                    )
                     message = format_trade(
                         template,
                         ticker=symbol,

--- a/tests/fixtures/sample_orders.json
+++ b/tests/fixtures/sample_orders.json
@@ -3,7 +3,12 @@
     "orderId": 1,
     "orderLegCollection": [
       {
-        "instrument": {"symbol": "AAPL", "underlyingSymbol": "AAPL"},
+        "instrument": {
+          "symbol": "AAPL",
+          "underlyingSymbol": "AAPL",
+          "maturityDate": "2024-01-19",
+          "strikePrice": 170.0
+        },
         "instruction": "BUY",
         "quantity": 10
       }
@@ -20,12 +25,22 @@
     "orderId": 2,
     "orderLegCollection": [
       {
-        "instrument": {"symbol": "MSFT", "underlyingSymbol": "MSFT"},
+        "instrument": {
+          "symbol": "MSFT",
+          "underlyingSymbol": "MSFT",
+          "maturityDate": "2024-02-16",
+          "strikePrice": 260.0
+        },
         "instruction": "SELL",
         "quantity": 5
       },
       {
-        "instrument": {"symbol": "MSFT", "underlyingSymbol": "MSFT"},
+        "instrument": {
+          "symbol": "MSFT",
+          "underlyingSymbol": "MSFT",
+          "maturityDate": "2024-02-16",
+          "strikePrice": 260.0
+        },
         "instruction": "BUY",
         "quantity": 5
       }

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -21,6 +21,8 @@ def test_flatten_data_single():
         "instruction": "BUY",
         "qty": 10,
         "price": 100.0,
+        "expiration": "2024-01-19",
+        "strike": 170.0,
         "order_id": 1,
         "time": "2024-01-01T00:00:00.000Z",
         "multi_leg": False
@@ -37,6 +39,8 @@ def test_flatten_dataset_full():
             "instruction": "BUY",
             "qty": 10,
             "price": 100.0,
+            "expiration": "2024-01-19",
+            "strike": 170.0,
             "order_id": 1,
             "time": "2024-01-01T00:00:00.000Z",
             "multi_leg": False
@@ -47,6 +51,8 @@ def test_flatten_dataset_full():
             "instruction": "SELL",
             "qty": 5,
             "price": 200.0,
+            "expiration": "2024-02-16",
+            "strike": 260.0,
             "order_id": 2,
             "time": "2024-01-02T00:00:00.000Z",
             "multi_leg": True
@@ -57,6 +63,8 @@ def test_flatten_dataset_full():
             "instruction": "BUY",
             "qty": 5,
             "price": 201.0,
+            "expiration": "2024-02-16",
+            "strike": 260.0,
             "order_id": 2,
             "time": "2024-01-02T00:00:00.000Z",
             "multi_leg": True

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -38,7 +38,14 @@ def test_poll_schwab_tracks_changes(monkeypatch):
         tracker = PriceTracker()
 
         def fake_flatten(data):
-            return [{"symbol": "AAPL", "price": 100.0}]
+            return [
+                {
+                    "symbol": "AAPL",
+                    "price": 100.0,
+                    "expiration": "2024-01-19",
+                    "strike": 170.0,
+                }
+            ]
 
         monkeypatch.setattr("poller.flatten_dataset", fake_flatten)
         sent = []
@@ -119,6 +126,8 @@ def test_poll_schwab_updates_position_tracker(monkeypatch):
                     "price": 100.0,
                     "qty": 1,
                     "instruction": "BUY",
+                    "expiration": "2024-01-19",
+                    "strike": 170.0,
                 }
             ]
 
@@ -142,7 +151,9 @@ def test_poll_schwab_updates_position_tracker(monkeypatch):
 
     asyncio.run(run_poll())
     assert position.add_trade.call_count >= 1
-    position.add_trade.assert_any_call("AAPL", 1.0, 100.0, "BUY")
+    position.add_trade.assert_any_call(
+        "AAPL", 1.0, 100.0, "BUY", "2024-01-19", 170.0
+    )
 
 
 def test_poll_schwab_logs_position_data(monkeypatch, caplog):
@@ -159,6 +170,8 @@ def test_poll_schwab_logs_position_data(monkeypatch, caplog):
                     "price": 100.0,
                     "qty": 1,
                     "instruction": "BUY",
+                    "expiration": "2024-01-19",
+                    "strike": 170.0,
                 }
             ]
 
@@ -194,6 +207,8 @@ def test_poll_schwab_template_includes_position(monkeypatch):
                     "price": 100.0,
                     "qty": 1,
                     "instruction": "BUY",
+                    "expiration": "2024-01-19",
+                    "strike": 170.0,
                 }
             ]
 

--- a/tests/test_position_tracker.py
+++ b/tests/test_position_tracker.py
@@ -8,13 +8,13 @@ from position_tracker import PositionTracker  # noqa: E402
 
 def test_open_partial_close_and_full_close():
     tracker = PositionTracker()
-    tracker.add_trade("AAPL", 10, 100.0, "BUY")
-    tracker.add_trade("AAPL", 10, 105.0, "BUY")
-    tracker.add_trade("AAPL", 15, 110.0, "SELL")
-    assert tracker.get_open_quantity("AAPL") == 5
-    pnl = tracker.calculate_pnl("AAPL")
+    tracker.add_trade("AAPL", 10, 100.0, "BUY", "2024-01-19", 170.0)
+    tracker.add_trade("AAPL", 10, 105.0, "BUY", "2024-01-19", 170.0)
+    tracker.add_trade("AAPL", 15, 110.0, "SELL", "2024-01-19", 170.0)
+    assert tracker.get_open_quantity("AAPL", "2024-01-19", 170.0) == 5
+    pnl = tracker.calculate_pnl("AAPL", "2024-01-19", 170.0)
     assert round(pnl, 2) == round(125 / 1525 * 100, 2)
-    tracker.add_trade("AAPL", 5, 120.0, "SELL")
-    assert tracker.get_open_quantity("AAPL") == 0
-    pnl = tracker.calculate_pnl("AAPL")
+    tracker.add_trade("AAPL", 5, 120.0, "SELL", "2024-01-19", 170.0)
+    assert tracker.get_open_quantity("AAPL", "2024-01-19", 170.0) == 0
+    pnl = tracker.calculate_pnl("AAPL", "2024-01-19", 170.0)
     assert round(pnl, 2) == round(200 / 2050 * 100, 2)


### PR DESCRIPTION
## Summary
- track positions per contract using expiration and strike
- include expiration/strike when flattening order data
- pass new contract details through poller
- update fixtures and tests for option fields

## Testing
- `flake8 . --exclude=.venv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9c74ac448323a1782c3fc4e3a54b