### PR TITLE
Add per-contract FIFO test

### DIFF
--- a/tests/test_position_tracker.py
+++ b/tests/test_position_tracker.py
@@ -18,3 +18,22 @@ def test_open_partial_close_and_full_close():
     assert tracker.get_open_quantity("AAPL", "2024-01-19", 170.0) == 0
     pnl = tracker.calculate_pnl("AAPL", "2024-01-19", 170.0)
     assert round(pnl, 2) == round(200 / 2050 * 100, 2)
+
+
+def test_fifo_by_contract():
+    """Lots with different expiration/strike should be tracked separately."""
+    tracker = PositionTracker()
+
+    # Open two contracts for the same symbol but different option details
+    tracker.add_trade("AAPL", 10, 100.0, "BUY", "2024-01-19", 170.0)
+    tracker.add_trade("AAPL", 5, 50.0, "BUY", "2024-02-16", 175.0)
+
+    # Close only the first contract
+    tracker.add_trade("AAPL", 10, 120.0, "SELL", "2024-01-19", 170.0)
+
+    assert tracker.get_open_quantity("AAPL", "2024-01-19", 170.0) == 0
+    assert tracker.get_open_quantity("AAPL", "2024-02-16", 175.0) == 5
+    pnl_first = tracker.calculate_pnl("AAPL", "2024-01-19", 170.0)
+    pnl_second = tracker.calculate_pnl("AAPL", "2024-02-16", 175.0)
+    assert round(pnl_first, 2) == round(200 / 1000 * 100, 2)
+    assert pnl_second == 0.0


### PR DESCRIPTION
## Summary
- add `test_fifo_by_contract` to ensure independent tracking by expiration & strike

## Testing
- `flake8 tests position_tracker.py poller.py tracker.py client.py discord_client.py flatten.py --exclude=.venv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa0d0854c83238b4701114dc31cc2