### PR TITLE
Enable Discord bot posting by channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Provide the following variables either in your shell environment or in a `.env` 
 - `SCHWAB_APP_KEY` – your Schwab API application key
 - `SCHWAB_APP_SECRET` – your Schwab API application secret
 - `POLL_INTERVAL` – (optional) seconds between API polls, default `5`
-- `DISCORD_WEBHOOK_URL` – (optional) Discord webhook URL to send trade updates
+- `DISCORD_BOT_TOKEN` – (optional) Discord bot token used for notifications
+- `DISCORD_CHANNEL_ID` – (optional) Discord channel ID where messages are sent
 
 ## Installation
 
@@ -33,7 +34,8 @@ Set the following variables when running the container:
 - `SCHWAB_APP_KEY`
 - `SCHWAB_APP_SECRET`
 - `POLL_INTERVAL` – (optional)
-- `DISCORD_WEBHOOK_URL` – (optional)
+- `DISCORD_BOT_TOKEN` – (optional)
+- `DISCORD_CHANNEL_ID` – (optional)
 
 Run the container with your credentials:
 
@@ -83,7 +85,7 @@ These objects can be written to a file or further processed as needed.
 ### Trade Messages
 
 Each flattened trade is formatted into a short string before being sent to
-Discord (if `DISCORD_WEBHOOK_URL` is configured). The default template is:
+Discord (if `DISCORD_BOT_TOKEN` is configured). The default template is:
 
 ```
 Contract {ticker} change {pct_change:.2f}%

--- a/discord_client.py
+++ b/discord_client.py
@@ -4,12 +4,20 @@ import requests
 
 
 def send_message(content: str) -> None:
-    """Send ``content`` to a Discord channel via webhook."""
-    webhook_url = os.getenv("DISCORD_WEBHOOK_URL")
-    if not webhook_url:
-        logging.error("DISCORD_WEBHOOK_URL not set")
+    """Send ``content`` to a Discord channel using a bot token."""
+    token = os.getenv("DISCORD_BOT_TOKEN")
+    channel_id = os.getenv("DISCORD_CHANNEL_ID")
+
+    if not token or not channel_id:
+        logging.error("DISCORD_BOT_TOKEN or DISCORD_CHANNEL_ID not set")
         return
+
+    url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
+    headers = {"Authorization": f"Bot {token}"}
+
     try:
-        requests.post(webhook_url, json={"content": content}, timeout=10)
+        requests.post(
+            url, json={"content": content}, headers=headers, timeout=10
+        )
     except requests.RequestException as exc:  # pragma: no cover - logging only
         logging.error("Failed to send Discord message: %s", exc)

--- a/tests/manual_tests.md
+++ b/tests/manual_tests.md
@@ -18,8 +18,8 @@
    - Run the poller with sample trades and verify that price changes are logged
      correctly for each contract.
 5. **Discord Notifications**
-   - Set `DISCORD_WEBHOOK_URL` to a test webhook and run the poller.
-   - Confirm messages are sent with the configured template.
+   - Set `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` in your environment.
+   - Run the poller and confirm messages appear in the channel.
 6. **Position Tracking**
    - Execute a sequence of buy and sell trades.
    - Verify that open quantities and realized PnL are updated according to FIFO logic.

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -10,17 +10,22 @@ from discord_client import send_message  # noqa: E402
 
 @patch('discord_client.requests.post')
 def test_send_message_posts(mock_post):
-    os.environ['DISCORD_WEBHOOK_URL'] = 'http://localhost/webhook'
+    os.environ['DISCORD_BOT_TOKEN'] = 'abc123'
+    os.environ['DISCORD_CHANNEL_ID'] = '42'
     send_message('hi')
     mock_post.assert_called_once_with(
-        'http://localhost/webhook', json={'content': 'hi'}, timeout=10
+        'https://discord.com/api/v10/channels/42/messages',
+        json={'content': 'hi'},
+        headers={'Authorization': 'Bot abc123'},
+        timeout=10,
     )
 
 
 @patch('discord_client.requests.post')
-def test_send_message_no_url(mock_post, caplog, monkeypatch):
-    monkeypatch.delenv('DISCORD_WEBHOOK_URL', raising=False)
+def test_send_message_missing_vars(mock_post, caplog, monkeypatch):
+    monkeypatch.delenv('DISCORD_BOT_TOKEN', raising=False)
+    monkeypatch.delenv('DISCORD_CHANNEL_ID', raising=False)
     with caplog.at_level('ERROR'):
         send_message('hi')
     mock_post.assert_not_called()
-    assert 'DISCORD_WEBHOOK_URL not set' in caplog.text
+    assert 'DISCORD_BOT_TOKEN or DISCORD_CHANNEL_ID not set' in caplog.text


### PR DESCRIPTION
## Summary
- update Discord client to use bot token & channel id
- adjust tests for Discord client
- document new env vars for Discord messages
- update manual test instructions

## Testing
- `flake8 discord_client.py tests/test_discord_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dd104ac0c83239be29df3477480af