### PR TITLE
Add trade status messages

### DIFF
--- a/messaging.py
+++ b/messaging.py
@@ -1,6 +1,27 @@
 from collections import defaultdict
 
 
+DEFAULT_TEMPLATE = (
+    "Contract {ticker} change {pct_change:.2f}% {expiration} {strike}"
+    " @${price:.2f} {status} {pct_gain:.2f}%"
+)
+
+
+def compose_trade_message(template: str | None = None, **values) -> str:
+    """Return a formatted trade message.
+
+    Parameters
+    ----------
+    template : str | None, optional
+        Format string with placeholders. If ``None`` the ``DEFAULT_TEMPLATE``
+        is used.
+    **values
+        Mapping of placeholder values used for formatting.
+    """
+    template = template or DEFAULT_TEMPLATE
+    return format_trade(template, **values)
+
+
 def format_trade(template: str, **values) -> str:
     """Fill ``template`` with values from ``values``.
 


### PR DESCRIPTION
## Summary
- detect trade status (opening, partial close, full close) in `poller.poll_schwab`
- compute per-trade percent gain and use new message template
- add `compose_trade_message` helper with default template
- verify messaging for open/partial/full close in tests

## Testing
- `flake8 . --exclude=.venv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8abebd1c83238d0f7112e3d843ab