### PR TITLE
Add average cost tracking and percent gain

### DIFF
--- a/poller.py
+++ b/poller.py
@@ -47,8 +47,17 @@ async def poll_schwab(
                     change = tracker.update_and_get_change(
                         symbol, float(price)
                     )
+                    pct_gain = 0.0
                     trade_pnl = None
                     if qty is not None and side is not None:
+                        side = side.upper()
+                        if side == "SELL":
+                            pct_gain = position_tracker.get_percent_gain(
+                                symbol,
+                                expiration,
+                                strike,
+                                float(price),
+                            )
                         try:
                             trade_pnl = position_tracker.add_trade(
                                 symbol,
@@ -69,19 +78,12 @@ async def poll_schwab(
 
                     status = ""
                     if side:
-                        side = side.upper()
                         if side == "BUY":
                             status = "Opening \U0001F7E2"
                         elif open_qty > 0:
                             status = "Partially Closed \U0001F7E1"
                         else:
                             status = "Fully Closed \U0001F7E5"
-
-                    pct_gain = 0.0
-                    if trade_pnl is not None and qty:
-                        basis = float(price) * float(qty) - trade_pnl
-                        if basis != 0:
-                            pct_gain = trade_pnl / basis * 100
 
                     message = compose_trade_message(
                         template,

--- a/tests/test_position_tracker.py
+++ b/tests/test_position_tracker.py
@@ -46,3 +46,30 @@ def test_fifo_by_contract():
     pnl_second = tracker.calculate_pnl("AAPL", "2024-02-16", 175.0)
     assert round(pnl_first, 2) == round(200 / 1000 * 100, 2)
     assert pnl_second == 0.0
+
+
+def test_percent_gain_multiple_buys_partial_sell():
+    tracker = PositionTracker()
+    tracker.add_trade("AAPL", 1, 100.0, "BUY", "2024-01-19", 170.0)
+    tracker.add_trade("AAPL", 1, 120.0, "BUY", "2024-01-19", 170.0)
+
+    gain = tracker.get_percent_gain(
+        "AAPL", "2024-01-19", 170.0, current_price=130.0
+    )
+    assert round(gain, 2) == round((130 - 110) / 110 * 100, 2)
+
+    pnl_trade = tracker.add_trade(
+        "AAPL", 1, 130.0, "SELL", "2024-01-19", 170.0
+    )
+    assert pnl_trade == 30.0
+    assert tracker.get_open_quantity("AAPL", "2024-01-19", 170.0) == 1
+
+    gain = tracker.get_percent_gain(
+        "AAPL", "2024-01-19", 170.0, current_price=115.0
+    )
+    assert round(gain, 2) == round((115 - 120) / 120 * 100, 2)
+
+    pnl_trade = tracker.add_trade(
+        "AAPL", 1, 115.0, "SELL", "2024-01-19", 170.0
+    )
+    assert pnl_trade == -5.0


### PR DESCRIPTION
## Summary
- store average cost of open lots in `PositionTracker`
- compute percent gain relative to current price using new `get_percent_gain`
- show gain using this method in `poller.poll_schwab`
- test gain calculation for multiple buys and partial sells

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8bd436e0832397f7e2b400b79eac