### PR TITLE
Add percent gain helper tests

### DIFF
--- a/poller.py
+++ b/poller.py
@@ -48,7 +48,6 @@ async def poll_schwab(
                         symbol, float(price)
                     )
                     pct_gain = 0.0
-                    trade_pnl = None
                     if qty is not None and side is not None:
                         side = side.upper()
                         if side == "SELL":
@@ -59,7 +58,7 @@ async def poll_schwab(
                                 float(price),
                             )
                         try:
-                            trade_pnl = position_tracker.add_trade(
+                            position_tracker.add_trade(
                                 symbol,
                                 float(qty),
                                 float(price),

--- a/position_tracker.py
+++ b/position_tracker.py
@@ -129,7 +129,8 @@ class PositionTracker:
         strike: float | None = None,
         current_price: float | None = None,
     ) -> float:
-        """Return percent difference between ``current_price`` and open average."""
+        """Return percent difference between ``current_price`` and open
+        average."""
         key = self._build_key(symbol, expiration, strike)
         avg_price = self.average_cost.get(key, 0.0)
         if not avg_price:

--- a/tests/test_position_tracker.py
+++ b/tests/test_position_tracker.py
@@ -73,3 +73,37 @@ def test_percent_gain_multiple_buys_partial_sell():
         "AAPL", 1, 115.0, "SELL", "2024-01-19", 170.0
     )
     assert pnl_trade == -5.0
+
+
+def test_average_cost_updates_and_reset():
+    tracker = PositionTracker()
+    key = ("AAPL", "", 0.0)
+    # first buy sets average cost
+    tracker.add_trade("AAPL", 1, 100.0, "BUY")
+    assert tracker.average_cost[key] == 100.0
+
+    # second buy updates weighted average
+    tracker.add_trade("AAPL", 1, 110.0, "BUY")
+    assert tracker.average_cost[key] == 105.0
+
+    # sell one lot recalculates average of remaining
+    tracker.add_trade("AAPL", 1, 120.0, "SELL")
+    assert tracker.average_cost[key] == 110.0
+
+    # sell remaining lot resets average cost to zero
+    tracker.add_trade("AAPL", 1, 115.0, "SELL")
+    assert tracker.get_open_quantity("AAPL") == 0
+    assert tracker.average_cost[key] == 0.0
+
+
+def test_calculate_pnl_zero_basis():
+    tracker = PositionTracker()
+    tracker.add_trade("AAPL", 1, 100.0, "BUY")
+    assert tracker.calculate_pnl("AAPL") == 0.0
+
+
+def test_get_percent_gain_negative_return():
+    tracker = PositionTracker()
+    tracker.add_trade("AAPL", 2, 100.0, "BUY")
+    gain = tracker.get_percent_gain("AAPL", current_price=90.0)
+    assert round(gain, 2) == round((90 - 100) / 100 * 100, 2)


### PR DESCRIPTION
## Summary
- test new `_update_average_cost` and `get_percent_gain` helpers
- fix flake8 issues in `poller.py` and `position_tracker.py`

## Testing
- `flake8 --exclude=.venv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8db7d8e0832387008f4b7da9e864