### PR TITLE
Add manual trade lifecycle test scenario

### DIFF
--- a/poller.py
+++ b/poller.py
@@ -48,7 +48,6 @@ async def poll_schwab(
                         symbol, float(price)
                     )
                     pct_gain = 0.0
-                    trade_pnl = None
                     if qty is not None and side is not None:
                         side = side.upper()
                         if side == "SELL":
@@ -59,7 +58,7 @@ async def poll_schwab(
                                 float(price),
                             )
                         try:
-                            trade_pnl = position_tracker.add_trade(
+                            position_tracker.add_trade(
                                 symbol,
                                 float(qty),
                                 float(price),

--- a/position_tracker.py
+++ b/position_tracker.py
@@ -129,7 +129,8 @@ class PositionTracker:
         strike: float | None = None,
         current_price: float | None = None,
     ) -> float:
-        """Return percent difference between ``current_price`` and open average."""
+        """Return the percent difference between the current price and
+        the open average."""
         key = self._build_key(symbol, expiration, strike)
         avg_price = self.average_cost.get(key, 0.0)
         if not avg_price:

--- a/tests/manual_tests.md
+++ b/tests/manual_tests.md
@@ -39,6 +39,7 @@
    - Execute a series of buys and sells that first partially close and then fully close a position.
    - Observe the log output for open quantity and PnL after each trade.
    - Check the Discord channel for messages showing `Opening`, `Partially Closed` and `Fully Closed` statuses along with the correct gain percentages.
+   - Ensure each message displays the gain formatted as a percentage next to the status.
 
 ## Docker Usage
 

--- a/tests/manual_tests.md
+++ b/tests/manual_tests.md
@@ -33,6 +33,13 @@
    - The open quantity should return to zero.
    - Verify the win/loss percentage equals total realized profit divided by the cost basis of the closed lots.
 
+9. **Trade Lifecycle with Discord Confirmation**
+   - Set `SCHWAB_APP_KEY`, `SCHWAB_APP_SECRET`, `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` in your environment.
+   - Run `python main.py` so trades are processed and messages are sent.
+   - Execute a series of buys and sells that first partially close and then fully close a position.
+   - Observe the log output for open quantity and PnL after each trade.
+   - Check the Discord channel for messages showing `Opening`, `Partially Closed` and `Fully Closed` statuses along with the correct gain percentages.
+
 ## Docker Usage
 
 1. **Build the Docker image**


### PR DESCRIPTION
## Summary
- describe how to run buys and sells to test partial/fully closed positions
- fix flake8 issues

## Testing
- `flake8 --exclude=.venv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8db6fc588323af679f38ff4bf14d