### PR TITLE
Fix syntax error in PositionTracker

### DIFF
--- a/position_tracker.py
+++ b/position_tracker.py
@@ -128,12 +128,9 @@ class PositionTracker:
         expiration: str | None = None,
         strike: float | None = None,
         current_price: float | None = None,
-    ) -> float:ikqyog-codex/add-manual-test-scenarios-in-tests/manual_tests.md
-        """Return the percent difference between the current price and
-        the open average."""
+    ) -> float:
         """Return percent difference between ``current_price`` and the
         average open cost."""
-        codex
         key = self._build_key(symbol, expiration, strike)
         avg_price = self.average_cost.get(key, 0.0)
         if not avg_price:


### PR DESCRIPTION
## Summary
- fix malformed annotation in `get_percent_gain`
- ensure linter and unit tests pass

## Testing
- `flake8 . --exclude=.venv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68802ecc065c8323820195ed95dfb99a